### PR TITLE
verlaufJS+scanJS improved, photo preview now proportional

### DIFF
--- a/css/scan.css
+++ b/css/scan.css
@@ -1,5 +1,5 @@
 @charset "utf-8";
-
+/* Styling Kamera Canvas */
 #camView {
   display: flex;
   flex-direction: column;
@@ -32,7 +32,10 @@
   background-image: url(../img/placeholder_cam.png);
   background-size: cover;
 }
-/* Styling Verlauf */
 #img_cache {
   display: none;
+}
+/* Styling Verlauf */
+.verlaufPic {
+	margin: 5px;
 }

--- a/css/scan.css
+++ b/css/scan.css
@@ -1,5 +1,5 @@
 @charset "utf-8";
-/* Styling Kamera Canvas */
+
 #camView {
   display: flex;
   flex-direction: column;
@@ -10,10 +10,11 @@
   overflow: hidden;
   }
 #camFooter div{
-  width: 80px;
+  width: 60px;
 }
 #camFooter {
-  margin-top: 30px;
+  bottom: 0px;
+  margin-top: 20px;
   padding: 0 20px 0 20px;
   display: flex;
   justify-content: space-between;
@@ -29,12 +30,9 @@
   width: 60px;
   height: 60px;
   background-image: url(../img/placeholder_cam.png);
-  background-size: contain;
-}
-#img_cache {
-  display: none;
+  background-size: cover;
 }
 /* Styling Verlauf */
-.verlaufPic {
-	margin: 5px;
+#img_cache {
+  display: none;
 }

--- a/js/scan.js
+++ b/js/scan.js
@@ -1,6 +1,5 @@
 // Variablen definieren
-var width = 300;
-var height;
+var width, height; // vars für konfiguration der canvas und foto-größe
 var video, img_cache, photo; // vars für Zugriff auf HTML ELemente
 var streaming = false; // zeigt ob stream zum ersten mal geöffnet wird oder nicht
 var picArray = []; // Array zum speichern gemachter Fotos
@@ -25,12 +24,13 @@ $(document).on("pageshow", "#scanpage", function () {
 		alert("Kamera-Fehler!"+err);
 	});
 	// Falls streaming = false, also Feed wird zum ersten Mal geöffnet:
-	// Größen konfigurieren + streaming = true damit keine Wiederholung bei nächstem Abruf
+	// Canvasgröße an Video angleichen + streaming = true damit keine Wiederholung bei nächstem Abruf
 	video.get(0).addEventListener('canplay', function () {
-		if (!streaming) {
-			height = video.get(0).videoHeight / (video.get(0).videoWidth / width);
-			img_cache.attr('width', width); //CHECK!!
-			img_cache.attr('height', height); //CHECK!!
+		if (!streaming) {			
+			width = video.get(0).videoWidth;
+			height = video.get(0).videoHeight;
+			img_cache.attr('width', width);
+			img_cache.attr('height', height);
 			streaming = true;
 		}
 	});	
@@ -43,7 +43,7 @@ img_cache.get(0).width = width;
 img_cache.get(0).height = height;
 context.drawImage(video.get(0), 0, 0, width, height);
 var data = img_cache.get(0).toDataURL('image/png');
-photo.attr('src', data);
+photo.attr('style', "background-image: url(" + data + ")");
 // Falls noch kein Eintrag im lStorage: Bild in Array speichern, Array in String umwandeln, String in lStorage speichern
 // Falls Eintrag vorhanden: 'altes' Array abrufen, aktualisieren, wieder in lStorage schreiben
 if(localStorage.getItem('picArray') === null) {

--- a/js/verlauf.js
+++ b/js/verlauf.js
@@ -1,18 +1,16 @@
 // Auslesen der Bilder aus dem Local Storage und Anzeigen auf Verlauf-Seite
-$(document).on("pageshow", "#verlauf", function(){
-    "use strict";
-	// Prüfen ob Eintrag in lStorage vorhanden, wenn nicht: Erstellen
-    if (localStorage.getItem("picArray") === null) {
-        picArray=[];
-        localStorage.setItem("picArray", JSON.stringify(picArray));
-    }
-    var verlaufArray;
-    var verlaufArrayL;
-	// Array aus lStorage abrufen & Länge ermitteln
-    verlaufArray = JSON.parse(localStorage.getItem("picArray"));
-    verlaufArrayL = verlaufArray.length;
-	// Daten aus Array darstellen
-    for ( var i=0; i<verlaufArrayL; i++ ) {
-        $("#content_verlauf").append('<img class="verlaufPic" src ='+verlaufArray[i]+'>');
-    }
+$(document).on("pageshow", "#verlauf", function () {
+	"use strict";
+	// Falls Bilder in lStorage: Anzeigen
+	if (localStorage.getItem("picArray") !== null) {
+		var verlaufArray;
+		var verlaufArrayL;
+		// Array aus lStorage abrufen & Länge ermitteln
+		verlaufArray = JSON.parse(localStorage.getItem("picArray"));
+		verlaufArrayL = verlaufArray.length;
+		// Daten aus Array darstellen
+		for (var i = 0; i < verlaufArrayL; i++) {
+			$("#content_verlauf").append('<img class="verlaufPic" src =' + verlaufArray[i] + '>');
+		}
+	}
 });


### PR DESCRIPTION
- verlauf.js is only executed if picArray found in lStorage ( _makes initial lStorage call unneccessary_);
- scan.js sets canvas size directly corresponding to video size ( _no stupid calculations_);
- photo preview uses background-image for correct proportions